### PR TITLE
Virtual keyboard support, control improvements, cutscene audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - ZR : Drink Mana Potion
 - ZL : Drink Heal Potion
 - Left Analog Click : Quest Log
-- Right Analog Click : Left mouse click
+- Right Analog Click : Left mouse click (skip intro etc.)
 - Minus : Automap
 - Plus : Game Menu
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - ZR : Drink Mana Potion
 - ZL : Drink Heal Potion
 - Left Analog Click : Quest Log
-- Right Analog Click : Perform left mouse click action on selected object or monster
+- Right Analog Click : Left mouse click
 - Minus : Automap
 - Plus : Game Menu
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -69,8 +69,6 @@ char *spszMsgTbl[4] = {
 };                                                      // weak
 char *spszMsgKeyTbl[4] = { "F9", "F10", "F11", "F12" }; // weak
 
-extern void PollSwitchStick();
-
 void FreeGameMem()
 {
 	music_stop();

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -1,5 +1,5 @@
 #if defined(SWITCH)
-#include <switch.h>
+	#include <switch.h>
 #endif
 #include "diablo.h"
 #include "../3rdParty/Storm/Source/storm.h"

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1,6 +1,3 @@
-#if defined(SWITCH)
-	#include <switch.h>
-#endif
 #include "diablo.h"
 #include "../3rdParty/Storm/Source/storm.h"
 

--- a/Source/plrctrls.cpp
+++ b/Source/plrctrls.cpp
@@ -1,6 +1,3 @@
-#if defined(SWITCH)
-	#include <switch.h>
-#endif
 #include "diablo.h"
 #include "../3rdParty/Storm/Source/storm.h"
  

--- a/SourceX/DiabloUI/diabloui.cpp
+++ b/SourceX/DiabloUI/diabloui.cpp
@@ -6,6 +6,11 @@
 
 #include "DiabloUI/diabloui.h"
 
+#ifdef SWITCH
+// for virtual keyboard on Switch
+#include "../../switch/switch_keyboard.h"
+#endif
+
 namespace dvl {
 
 TTF_Font *font;
@@ -155,6 +160,9 @@ void UiInitList(int min, int max, void (*fnFocus)(int value), void (*fnSelect)(i
 	SDL_StopTextInput(); // input is enabled by default
 	for (int i = 0; i < itemCnt; i++) {
 		if (items[i].type == UI_EDIT) {
+#ifdef SWITCH
+			switch_start_text_input(items[i-1].caption, items[i].caption, 0);
+#endif
 			SDL_StartTextInput();
 			UiTextInput = items[i].caption;
 			UiTextInputLen = items[i].value;

--- a/SourceX/main.cpp
+++ b/SourceX/main.cpp
@@ -1,6 +1,3 @@
-#if defined(SWITCH)
-	#include <switch.h>
-#endif
 #include <string>
 #include <SDL.h>
 

--- a/SourceX/miniwin/misc.cpp
+++ b/SourceX/miniwin/misc.cpp
@@ -1,7 +1,3 @@
-#if defined(SWITCH)
-	#include <switch.h>
-#endif
-
 #include "devilution.h"
 #include "miniwin/ddraw.h"
 #include "stubs.h"

--- a/SourceX/miniwin/misc_io.cpp
+++ b/SourceX/miniwin/misc_io.cpp
@@ -1,6 +1,3 @@
-#if defined(SWITCH)
-	#include <switch.h>
-#endif
 #include <cstdio>
 #include <set>
 #include <string>

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -1,10 +1,8 @@
 #include <deque>
 #include <SDL.h>
-#if defined(SWITCH)
-	#include <switch.h>
-#endif
 #include "devilution.h"
 #include "stubs.h"
+#include <math.h>
 
 /** @file
  * *
@@ -15,21 +13,29 @@
 namespace dvl {
 
 bool conInv = false;
-float leftStickX;
-float leftStickY;
-float rightStickX;
-float rightStickY;
-float leftTrigger;
-float rightTrigger;
-float deadzoneX;
-float deadzoneY;
+float leftStickX = 0;
+float leftStickY = 0;
+float rightStickX = 0;
+float rightStickY = 0;
+float leftTrigger = 0;
+float rightTrigger = 0;
+float rightDeadzone = 0.07;
+float leftDeadzone = 0.07;
 int doAttack 	= 0;
 int doUse 		= 0;
 int doChar 		= 0;
 
-JoystickPosition pos_left, pos_right;
+static int leftStickXUnscaled = 0; // raw axis values reported by SDL_JOYAXISMOTION
+static int leftStickYUnscaled = 0;
+static int rightStickXUnscaled = 0;
+static int rightStickYUnscaled = 0;
+static int hiresDX = 0;   // keep track of X/Y sub-pixel per frame mouse motion
+static int hiresDY = 0;
+static int64_t currentTime = 0; // used to update joystick mouse once per frame
+static int64_t lastTime = 0;
+static void ScaleJoystickAxes(float *x, float *y, float deadzone);
+static void HandleJoystickAxes();
 
-void PollSwitchStick();
 static std::deque<MSG> message_queue;
 
 static int translate_sdl_key(SDL_Keysym key)
@@ -123,13 +129,13 @@ static WINBOOL false_avail()
 
 WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax, UINT wRemoveMsg)
 {
-	static signed short rstick_x;
-	static signed short lstick_x;
-	static signed short rstick_y;
-	static signed short lstick_y;
+	// update joystick mouse at maximally 60 fps
+	currentTime = SDL_GetTicks();
+	if ((currentTime - lastTime) > 15) {
+		HandleJoystickAxes();
+		lastTime = currentTime;
+	}
 	
-	static short lastmouseX, lastmouseY;	
- 
 	if (wMsgFilterMin != 0)
 		UNIMPLEMENTED();
 	if (wMsgFilterMax != 0)
@@ -163,7 +169,26 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 
 	switch (e.type) { 
 	case SDL_JOYAXISMOTION:
-		PollSwitchStick();
+		switch (e.jaxis.axis) {
+			case 0:
+				leftStickXUnscaled = e.jaxis.value;
+				break;
+			case 1:
+				leftStickYUnscaled = -e.jaxis.value;
+				break;
+			case 2:
+				rightStickXUnscaled = e.jaxis.value;
+				break;
+			case 3:
+				rightStickYUnscaled = -e.jaxis.value;
+				break;
+		}
+		leftStickX = leftStickXUnscaled;
+		leftStickY = leftStickYUnscaled;
+		ScaleJoystickAxes(&leftStickX, &leftStickY, leftDeadzone);
+		rightStickX = rightStickXUnscaled;
+		rightStickY = rightStickYUnscaled;
+		ScaleJoystickAxes(&rightStickX, &rightStickY, rightDeadzone);
 		lpMsg->message = e.type == SDL_KEYUP;
 		lpMsg->lParam = 0;
 		break;
@@ -481,47 +506,65 @@ WINBOOL PostMessageA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 	return true;
 }
 
-void PollSwitchStick()
+void ScaleJoystickAxes(float *x, float *y, float deadzone)
 {
-	int h,k = 0;
-	hidScanInput();
-	
-	//Read the joysticks' position
-	hidJoystickRead(&pos_left, CONTROLLER_P1_AUTO, JOYSTICK_LEFT);
-	hidJoystickRead(&pos_right, CONTROLLER_P1_AUTO, JOYSTICK_RIGHT);
- 
-	float normLX = fmaxf(-1, (float)pos_left.dx / 8000);
-	float normLY = fmaxf(-1, (float)pos_left.dy / 8000);
+	//radial and scaled dead_zone
+	//http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html
+	//input values go from -32767.0...+32767.0, output values are from -1.0 to 1.0;
 
-	leftStickX = (abs(normLX) < deadzoneX ? 0 : (abs(normLX) - deadzoneX) * (normLX / abs(normLX)));
-	leftStickY = (abs(normLY) < deadzoneY ? 0 : (abs(normLY) - deadzoneY) * (normLY / abs(normLY)));
+	if (deadzone == 0) {
+		return;
+	}
+	if (deadzone >= 1.0) {
+		*x = 0;
+		*y = 0;
+		return;
+	}
 
-	if (deadzoneX > 0)
-		leftStickX *= 1 / (1 - deadzoneX);
-	if (deadzoneY > 0)
-		leftStickY *= 1 / (1 - deadzoneY);
- 
-	float normRX = fmaxf(-1, (float)pos_right.dx / 32768);
-	float normRY = fmaxf(-1, (float)pos_right.dy / 32768);
+	const float maximum = 32767.0f;
+	float analog_x = *x;
+	float analog_y = *y;
+	float dead_zone = deadzone * maximum;
 
-	rightStickX = (abs(normRX) < deadzoneX ? 0 : (abs(normRX) - deadzoneX) * (normRX / abs(normRX)));
-	rightStickY = (abs(normRY) < deadzoneY ? 0 : (abs(normRY) - deadzoneY) * (normRY / abs(normRY)));
+	float magnitude = sqrtf(analog_x * analog_x + analog_y * analog_y);
+	if (magnitude >= dead_zone) {
+		// find scaled axis values with magnitudes between zero and maximum
+		float scalingFactor = 1.0 / magnitude * (magnitude - dead_zone) / (maximum - dead_zone);
+		analog_x = (analog_x * scalingFactor);
+		analog_y = (analog_y * scalingFactor);
 
-	if (deadzoneX > 0)
-		rightStickX *= 1 / (1 - deadzoneX);
-	if (deadzoneY > 0)
-		rightStickY *= 1 / (1 - deadzoneY);
- 
-	// right joystick
-	if (rightStickX > 0.05 || rightStickY > 0.05 || rightStickX < -0.05 || rightStickY < -0.05) {
+		// clamp to ensure results will never exceed the max_axis value
+		float clamping_factor = 1.0f;
+		float abs_analog_x = fabs(analog_x);
+		float abs_analog_y = fabs(analog_y);
+		if (abs_analog_x > 1.0 || abs_analog_y > 1.0){
+			if (abs_analog_x > abs_analog_y) {
+				clamping_factor = 1 / abs_analog_x;
+			} else {
+				clamping_factor = 1 / abs_analog_y;
+			}
+		}
+		*x = (clamping_factor * analog_x);
+		*y = (clamping_factor * analog_y);
+	} else {
+		*x = 0;
+		*y = 0;
+	}
+}
+
+static void HandleJoystickAxes()
+{
+	// deadzone is handled in ScaleJoystickAxes() already
+	if (rightStickX != 0 || rightStickY != 0) {
+		// right joystick
 		if (automapflag) { // move map
-			if (rightStickY < 0.05)
+			if (rightStickY < -0.5)
 				AutomapUp();
-			else if (rightStickY > 0.05)
+			else if (rightStickY > 0.5)
 				AutomapDown();
-			else if (rightStickX < 0.05)
+			else if (rightStickX < -0.5)
 				AutomapRight();
-			else if (rightStickX > 0.05)
+			else if (rightStickX > 0.5)
 				AutomapLeft();
 		} else { // move cursor
 			if (pcurs == CURSOR_NONE) {
@@ -529,16 +572,12 @@ void PollSwitchStick()
 				newCurHidden = false;
 			}
 
-			static int hiresDX = 0;   // keep track of X sub-pixel per frame mouse motion
-			static int hiresDY = 0;   // keep track of Y sub-pixel per frame mouse motion
-			const int slowdown = 128; // increase/decrease this to decrease/increase mouse speed
+			const int slowdown = 80; // increase/decrease this to decrease/increase mouse speed
 
 			int x = MouseX;
 			int y = MouseY;
-			if (rightStickX > 0.05 || rightStickX < 0.05)
-				hiresDX += rightStickX * 256.0;
-			if (rightStickY > 0.05 || rightStickY < 0.05)
-				hiresDY += rightStickY * 256.0;
+			hiresDX += rightStickX * 256.0;
+			hiresDY += rightStickY * 256.0;
 
 			x += hiresDX / slowdown;
 			y += -(hiresDY) / slowdown;
@@ -556,6 +595,5 @@ void PollSwitchStick()
 			MouseY = y;
 		}
 	} 
-  
 }
 }

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -207,11 +207,9 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 					SetCursor_(CURSOR_HAND);
 					newCurHidden = false;
 				}
-				if (spselflag) {
-					SetSpell();
-				} else {
-					LeftMouseCmd(false);
-				}
+				lpMsg->message = DVL_WM_LBUTTONDOWN;
+				lpMsg->lParam = (MouseY << 16) | (MouseX & 0xFFFF);
+				lpMsg->wParam = keystate_for_mouse(DVL_MK_LBUTTON);
 				break;
 			case  6:	// L
 				PressChar('h');
@@ -311,6 +309,11 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 					lpMsg->lParam = (MouseY << 16) | (MouseX & 0xFFFF);
 					lpMsg->wParam = keystate_for_mouse(0);
 				}
+				break;
+			case  5:	// right joystick click
+				lpMsg->message = DVL_WM_LBUTTONUP;
+				lpMsg->lParam = (MouseY << 16) | (MouseX & 0xFFFF);
+				lpMsg->wParam = keystate_for_mouse(0);
 				break;
 		}
 		#endif

--- a/SourceX/storm/storm.cpp
+++ b/SourceX/storm/storm.cpp
@@ -453,11 +453,7 @@ BOOL SVidPlayBegin(char *filename, int a2, int a3, int a4, int a5, int flags, HA
 
 	SVidLoop = flags & 0x40000;
 	bool enableVideo = !(flags & 0x100000);
-#ifdef SWITCH
-	bool enableAudio = 0;
-#else	
 	bool enableAudio = !(flags & 0x1000000);
-#endif
 	//0x8 // Non-interlaced
 	//0x200, 0x800 // Upscale video
 	//0x80000 // Center horizontally
@@ -480,6 +476,9 @@ BOOL SVidPlayBegin(char *filename, int a2, int a3, int a4, int a5, int flags, HA
 	unsigned long rate[7];
 	smk_info_audio(SVidSMK, NULL, channels, depth, rate);
 	if (enableAudio && depth[0] != 0) {
+#ifdef SWITCH
+		Mix_CloseAudio();
+#endif
 		smk_enable_audio(SVidSMK, 0, enableAudio);
 		SDL_AudioSpec audioFormat;
 		SDL_zero(audioFormat);
@@ -490,6 +489,11 @@ BOOL SVidPlayBegin(char *filename, int a2, int a3, int a4, int a5, int flags, HA
 		deviceId = SDL_OpenAudioDevice(NULL, 0, &audioFormat, NULL, 0);
 		if (deviceId == 0) {
 			SDL_Log(SDL_GetError());
+#ifdef SWITCH
+			Mix_OpenAudio(22050, AUDIO_S16LSB, 2, 1024);
+			Mix_AllocateChannels(25);
+			Mix_ReserveChannels(1);
+#endif
 			return false;
 		} else {
 			SDL_PauseAudioDevice(deviceId, 0); /* start audio playing. */
@@ -638,6 +642,11 @@ BOOL SVidPlayEnd(HANDLE video)
 	if (deviceId) {
 		SDL_ClearQueuedAudio(deviceId);
 		SDL_CloseAudioDevice(deviceId);
+#ifdef SWITCH
+		Mix_OpenAudio(22050, AUDIO_S16LSB, 2, 1024);
+		Mix_AllocateChannels(25);
+		Mix_ReserveChannels(1);
+#endif
 		deviceId = 0;
 	}
 

--- a/makefile
+++ b/makefile
@@ -68,7 +68,7 @@ RADONOBJ		= obj/File.o obj/Key.o obj/Named.o obj/Section.o
 STORMLIBOBJ 	= obj/FileStream.o obj/SBaseCommon.o obj/SBaseFileTable.o obj/SBaseSubTypes.o obj/SCompression.o obj/SFileExtractFile.o obj/SFileFindFile.o obj/SFileGetFileInfo.o obj/SFileOpenArchive.o obj/SFileOpenFileEx.o obj/SFileReadFile.o
 PKWAREOBJ		= obj/explode.o obj/implode.o
 DEVILUTIONOBJ 	= obj/appfat.o obj/automap.o obj/capture.o obj/codec.o obj/control.o obj/cursor.o obj/dead.o obj/debug.o obj/diablo.o obj/doom.o obj/drlg_l1.o obj/drlg_l2.o obj/drlg_l3.o obj/drlg_l4.o obj/dthread.o obj/effects.o obj/encrypt.o obj/engine.o obj/error.o obj/fault.o obj/gamemenu.o obj/gendung.o obj/gmenu.o obj/help.o obj/init.o obj/interfac.o obj/inv.o obj/itemdat.o obj/items.o obj/lighting.o obj/loadsave.o obj/logging.o obj/mmainmenu.o obj/minitext.o obj/misdat.o obj/missiles.o obj/monstdat.o obj/monster.o obj/movie.o obj/mpqapi.o obj/msgcmd.o obj/msg.o obj/multi.o obj/nthread.o obj/objdat.o obj/objects.o obj/pack.o obj/palette.o obj/path.o obj/pfile.o obj/player.o obj/plrctrls.o obj/plrmsg.o obj/portal.o obj/spelldat.o obj/quests.o obj/render.o obj/restrict.o obj/scrollrt.o obj/setmaps.o obj/sha.o obj/spells.o obj/stores.o obj/sync.o obj/textdat.o obj/themes.o obj/tmsg.o obj/town.o obj/towners.o obj/track.o obj/trigs.o obj/wave.o
-MAINOBJ			= obj/dx.o obj/misc.o obj/misc_io.o obj/misc_msg.o obj/misc_dx.o obj/rand.o obj/thread.o obj/dsound.o obj/ddraw.o obj/sound.o obj/storm.o obj/storm_net.o obj/storm_dx.o obj/abstract_net.o obj/loopback.o obj/packet.o obj/base.o obj/frame_queue.o obj/tcp_client.o obj/tcp_server.o obj/udp_p2p.o obj/credits.o obj/diabloui.o obj/dialogs.o obj/mainmenu.o obj/progress.o obj/selconn.o obj/selgame.o obj/selhero.o obj/title.o obj/main.o
+MAINOBJ			= obj/dx.o obj/misc.o obj/misc_io.o obj/misc_msg.o obj/misc_dx.o obj/rand.o obj/thread.o obj/dsound.o obj/ddraw.o obj/sound.o obj/storm.o obj/storm_net.o obj/storm_dx.o obj/abstract_net.o obj/loopback.o obj/packet.o obj/base.o obj/frame_queue.o obj/tcp_client.o obj/tcp_server.o obj/udp_p2p.o obj/credits.o obj/diabloui.o obj/dialogs.o obj/mainmenu.o obj/progress.o obj/selconn.o obj/selgame.o obj/selhero.o obj/title.o obj/main.o obj/switch_keyboard.o
 
 LIBS      	= -specs=$(DEVKITPRO)/libnx/switch.specs -g -march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE -L$(DEVKITPRO)/libnx/lib -L$(DEVKITPRO)/portlibs/switch/lib -lSDL2_mixer -lSDL2_ttf -lfreetype -lvorbisfile -lvorbis -logg -lmodplug -lmikmod -lmpg123 -lSDL2 -lopusfile -lopus -lEGL -lglapi -ldrm_nouveau -lpng -lbz2 -lz -lnx 
 INCS      	= -I$(DEVKITPRO)/portlibs/switch/include/SDL2 -I"Source" -I"SourceS" -I"SourceX" -I"3rdParty/asio/include" -I"3rdParty/Radon/Radon/include" -I"3rdParty/libsmacker" -I$(DEVKITPRO)/libnx/include -I$(DEVKITPRO)/portlibs/switch/include
@@ -354,7 +354,8 @@ obj/title.o: $(GLOBALDEPS) SourceX/DiabloUI/title.cpp
 	$(CPP) -c SourceX/DiabloUI/title.cpp -o obj/title.o $(CXXFLAGS)		
 obj/main.o: $(GLOBALDEPS) SourceX/main.cpp
 	$(CPP) -c SourceX/main.cpp -o obj/main.o $(CXXFLAGS)		
-		
+obj/switch_keyboard.o: $(GLOBALDEPS) switch/switch_keyboard.cpp
+	$(CPP) -c switch/switch_keyboard.cpp -o obj/switch_keyboard.o $(CXXFLAGS)		
  
 #---------------------------------------------------------------------------------
 # main targets

--- a/switch/switch_keyboard.cpp
+++ b/switch/switch_keyboard.cpp
@@ -1,0 +1,78 @@
+#include <string.h>
+#include <stdbool.h>
+
+#include <switch.h>
+#include <SDL.h>
+#include "switch_keyboard.h"
+
+static void switch_keyboard_get(char *guide_text, char *initial_text, int max_len, int multiline, char *buf)
+{
+    Result rc = 0;
+
+    SwkbdConfig kbd;
+
+    rc = swkbdCreate(&kbd, 0);
+
+    if (R_SUCCEEDED(rc)) {
+        swkbdConfigMakePresetDefault(&kbd);
+        swkbdConfigSetGuideText(&kbd, guide_text);
+        swkbdConfigSetInitialText(&kbd, initial_text);
+        swkbdConfigSetStringLenMax(&kbd, max_len);
+        rc = swkbdShow(&kbd, buf, max_len);
+        swkbdClose(&kbd);
+    }
+}
+
+static int get_utf8_character_bytes(const uint8_t *uc)
+{
+    if (uc[0] < 0x80) {
+        return 1;
+    } else if ((uc[0] & 0xe0) == 0xc0 && (uc[1] & 0xc0) == 0x80) {
+        return 2;
+    } else if ((uc[0] & 0xf0) == 0xe0 && (uc[1] & 0xc0) == 0x80 && (uc[2] & 0xc0) == 0x80) {
+        return 3;
+    } else if ((uc[0] & 0xf8) == 0xf0 && (uc[1] & 0xc0) == 0x80 && (uc[2] & 0xc0) == 0x80 && (uc[3] & 0xc0) == 0x80) {
+        return 4;
+    } else {
+        return 1;
+    }
+}
+
+static void switch_create_and_push_sdlkey_event(uint32_t event_type, SDL_Scancode scan, SDL_Keycode key)
+{
+    SDL_Event event;
+    event.type = event_type;
+    event.key.keysym.scancode = scan;
+    event.key.keysym.sym = key;
+    event.key.keysym.mod = 0;
+    SDL_PushEvent(&event);
+}
+
+void switch_start_text_input(char *guide_text, char *initial_text, int multiline)
+{
+    char text[65] = {'\0'};
+    switch_keyboard_get(guide_text, initial_text, 64, multiline, text);
+    if (text == nullptr) {
+        return;
+    }
+    for (int i = 0; i < 600; i++) {
+        switch_create_and_push_sdlkey_event(SDL_KEYDOWN, SDL_SCANCODE_BACKSPACE, SDLK_BACKSPACE);
+        switch_create_and_push_sdlkey_event(SDL_KEYUP, SDL_SCANCODE_BACKSPACE, SDLK_BACKSPACE);
+    }
+    for (int i = 0; i < 600; i++) {
+        switch_create_and_push_sdlkey_event(SDL_KEYDOWN, SDL_SCANCODE_DELETE, SDLK_DELETE);
+        switch_create_and_push_sdlkey_event(SDL_KEYUP, SDL_SCANCODE_DELETE, SDLK_DELETE);
+    }
+    const uint8_t *utf8_text = (uint8_t*) text;
+    for (int i = 0; i < 599 && utf8_text[i];) {
+        int bytes_in_char = get_utf8_character_bytes(&utf8_text[i]);
+        SDL_Event textinput_event;
+        textinput_event.type = SDL_TEXTINPUT;
+        for (int n = 0; n < bytes_in_char; n++) {
+            textinput_event.text.text[n] = text[i + n];
+        }
+        textinput_event.text.text[bytes_in_char] = 0;
+        SDL_PushEvent(&textinput_event);
+        i += bytes_in_char;
+    }
+}

--- a/switch/switch_keyboard.h
+++ b/switch/switch_keyboard.h
@@ -2,4 +2,5 @@
 #define SWITCH_KEYBOARD_H
 
 void switch_start_text_input(char *guide_text, char *initial_text, int multiline);
-#endif /* OPENRCT2_UI_SWITCH_KEYBOARD_H */
+
+#endif /* SWITCH_KEYBOARD_H */

--- a/switch/switch_keyboard.h
+++ b/switch/switch_keyboard.h
@@ -1,0 +1,5 @@
+#ifndef SWITCH_KEYBOARD_H
+#define SWITCH_KEYBOARD_H
+
+void switch_start_text_input(char *guide_text, char *initial_text, int multiline);
+#endif /* OPENRCT2_UI_SWITCH_KEYBOARD_H */


### PR DESCRIPTION
This PR includes the following fixes
- fix right stick click. It can now be used also to push buttons on the panel. Coincidentally, this allows  right stick click to skip the intro, too! 
- implement virtual keyboard support (name entry, etc.). The keyboard opens at the same time when SDL_StartTextInput is called in the code.
- fix horizontal scrolling of automap with right stick
- implement proper radial deadzones for analog sticks
- use only SDL for joystick axis handling (removes libnx dependency in event handling code)
- fix cutscene audio

Closes #5 

![](https://i.postimg.cc/J4qmg0xN/diablo-1.jpg)
![](https://i.postimg.cc/brPcVf2V/diablo-2.jpg)
