### PR TITLE
Fix button presses causing crash while intro plays

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 - ZR : Drink Mana Potion
 - ZL : Drink Heal Potion
 - Left Analog Click : Quest Log
-- Right Analog Click : Left mouse click (skip intro etc.)
+- Right Analog Click : Left mouse click
 - Minus : Automap
-- Plus : Game Menu
+- Plus : Game Menu, Skip Intro
 
 ### Notes
 

--- a/SourceX/miniwin/misc_msg.cpp
+++ b/SourceX/miniwin/misc_msg.cpp
@@ -167,6 +167,51 @@ WINBOOL PeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilter
 	lpMsg->lParam = 0;
 	lpMsg->wParam = 0;
 
+#ifdef SWITCH
+	if (movie_playing) {
+		// allow plus button or mouse click to skip movie, no other input
+		switch (e.type) { 
+			case SDL_JOYBUTTONDOWN:
+				switch(e.jbutton.button)
+				{
+					case 10:	// plus
+					case  5:	// right joystick click
+						lpMsg->message = DVL_WM_LBUTTONDOWN;
+						lpMsg->lParam = (MouseY << 16) | (MouseX & 0xFFFF);
+						lpMsg->wParam = keystate_for_mouse(DVL_MK_LBUTTON);
+						break;
+				}
+				break;
+			case SDL_JOYBUTTONUP:
+				switch(e.jbutton.button)
+				{
+					case  10:	// plus
+					case   5:	// right joystick click
+						lpMsg->message = DVL_WM_LBUTTONUP;
+						lpMsg->lParam = (MouseY << 16) | (MouseX & 0xFFFF);
+						lpMsg->wParam = keystate_for_mouse(0);
+						break;
+				}
+				break;
+			case SDL_MOUSEBUTTONDOWN: 
+				if (e.button.button == SDL_BUTTON_LEFT) {
+					lpMsg->message = DVL_WM_LBUTTONDOWN;
+					lpMsg->lParam = (e.button.y << 16) | (e.button.x & 0xFFFF);
+					lpMsg->wParam = keystate_for_mouse(DVL_MK_LBUTTON);
+				}
+				break;
+			case SDL_MOUSEBUTTONUP:
+				if (e.button.button == SDL_BUTTON_LEFT) {
+					lpMsg->message = DVL_WM_LBUTTONUP;
+					lpMsg->lParam = (e.button.y << 16) | (e.button.x & 0xFFFF);
+					lpMsg->wParam = keystate_for_mouse(0);
+				}
+				break;
+		}
+		return true;
+	}
+#endif
+
 	switch (e.type) { 
 	case SDL_JOYAXISMOTION:
 		switch (e.jaxis.axis) {


### PR DESCRIPTION
Closes #18 

Now, left mouse click and plus button skip cutscenes. All other inputs are disabled during cutscenes.

This was related to the older bug of "I have no spell ready" sound playing and other game inputs triggering when pushing buttons while the intro was playing. 