### PR TITLE
prevent "spell not rdy" speech on exit dialog and makefile create dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - Extract contents of diablo-nx.zip release into SDMC:\switch\diablo-nx
 - Copy DIABDAT.MPQ from original Diablo game disc or GOG version.
 - Launch diablo-nx.nro
+  - *Note:* If using SX OS, hold R on any installed game and launch it.
 - Enjoy :)
 
 ### Controls
@@ -36,7 +37,6 @@ There are lots of bugs. Check issues on the code repo.
 ### Compiling On Windows
 
 - Install [devkitpro](https://sourceforge.net/projects/devkitpro/)
-- Make the folders ```obj```, ```release``` and ```RomFS``` in devilution source code folder.
 - Open ```Start Button > DevKitPro > MSys2```
 - Type in ```pacman -S switch-freetype switch-mesa switch-glad switch-glm switch-sdl2 switch-sdl2_ttf switch-sdl2_mixer switch-libvorbis switch-libmikmod```
 - Type in ```make```

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -464,10 +464,9 @@ void diablo_parse_flags(char *args)
 			case 'w':
 				debug_mode_key_w = 1;
 				break;
-			case 'x':
-				fullscreen = 0;
-				break;
-			}
+			//case 'x': // JAKE: Removed for spell casting
+			//	fullscreen = FALSE;
+			//	break;
 #endif
 		}
 	}
@@ -1421,8 +1420,12 @@ void PressChar(int vkey)
 		// JAKE: Spacebar used to go back, now Z goes back.
 		if (pcurs >= CURSOR_FIRSTITEM && invflag)
 			DropItemBeforeTrig();
-		//castwait = ticks;
-		if (!invflag && !talkflag)
+		ticks = GetTickCount();
+		if (ticks - castwait < 300 || ticks - talkwait < 600) { // prevent double spell cast
+			return;
+		}
+		castwait = ticks;
+		if (!invflag && !talkflag && !inmainmenu && stextflag == 0 && !qtextflag) // prevent "spell not rdy" speech
 			RightMouseDown();
 		PressEscKey();
 		return;

--- a/makefile
+++ b/makefile
@@ -2,6 +2,8 @@ ifeq ($(strip $(DEVKITPRO)),)
 $(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
 endif
 
+contents := $(shell mkdir -p obj ; mkdir -p release ; mkdir -p RomFS)
+
 TOPDIR ?= $(CURDIR)
  
 export BUILD_EXEFS_SRC := build/exefs


### PR DESCRIPTION
- Fix "spell not rdy" speech was happening on exiting dialog.
- Prevent double spell cast.
- makefile now creates required directories for compiling.
- Changed readme showing SX OS users proper way to launch game.