### PR TITLE
Add more specific MacOS build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ There are lots of bugs. Check issues on the code repo.
 ### Compiling On MacOS
 
 - Install [devkitpro](https://devkitpro.org/wiki/Getting_Started#macOS)
-- Open Terminal
-- Type in ```dkp-pacman -S switch-freetype switch-mesa switch-glad switch-glm switch-sdl2 switch-sdl2_ttf switch-sdl2_mixer switch-libvorbis switch-libmikmod```
-- Type in ```make```
+- Open Terminal and run the following commands:
+- ```dkp-pacman -S switch-dev``` to install more build tools
+   - At a minimum, you will need to install `devkitA64` and `switch-tools`
+- ```dkp-pacman -S switch-freetype switch-mesa switch-glad switch-glm switch-sdl2 switch-sdl2_ttf switch-sdl2_mixer switch-libvorbis switch-libmikmod```
+- ```make```
 
 - .nro lives in release. Test with an emulator (RyuJinx) or real hardware.
 


### PR DESCRIPTION
Hello, and first of all, thank you for all the hard work you've put in here. It's really impressive to see this running on modern hardware like the switch.

I was going through the motions of compiling this on my laptop today, and found that
it wasn't completely clear, since neither the README here, nor the devkitpro website 
specifies the packages you'll need install for suchas the `elf2nso` tools.

My hope is that this makes it easier for the next person that comes along to get started.